### PR TITLE
Bump Helm chart version to 1.1.4

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,23 +2,8 @@ apiVersion: v2
 name: kbot
 description: A Helm chart for Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 1.1.4
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: "1.17.2"


### PR DESCRIPTION
This PR bumps the Helm chart version for kbot from 1.1.3 to 1.1.4 in Chart.yaml.